### PR TITLE
Tone down FlashVideo::Site::Channel5's greediness

### DIFF
--- a/lib/FlashVideo/Site/Channel5.pm
+++ b/lib/FlashVideo/Site/Channel5.pm
@@ -226,9 +226,6 @@ sub can_handle {
   my($self, $browser, $url) = @_;
 
   return 1 if $url && URI->new($url)->host =~ /\.channel5\.com$/;
-
-  return $browser->content =~ /(playerI[dD]|brightcove.player.create)/
-    && $browser->content =~ /brightcove/i;
 }
 
 1;


### PR DESCRIPTION
FlashVideo::Site::Channel5 claims it can_handle() anything containing brightcode videos, then proceeds to die when it bites off something FlashVideo::Site::Brightcove can chew better, for example http://ww3.tvo.org/video/173822/secret-life-chaos.

This fixes tvo.org and probably alot of others, the brightcove plugin is just as greedy but works as a generic plugin. (Untested) FlashVideo::URLFinder::_find_package_url should prioritize Channel5.pm for channel5. If not, can_handle_generic() seems like a good idea.
